### PR TITLE
Fix custom metrics race condition + add Meta reconnect banner

### DIFF
--- a/src/app/settings/page.jsx
+++ b/src/app/settings/page.jsx
@@ -462,7 +462,12 @@ function SettingsPageContent() {
                   <div className="flex items-center gap-2 flex-wrap">
                     {ghlStatus.connected ? (
                       <>
-
+                        {ghlStatus.token_expired && (
+                          <Button size="sm" variant="destructive" onClick={() => handleConnect("gohighlevel")} disabled={isLoading}>
+                            {isLoading && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+                            Reconnect
+                          </Button>
+                        )}
                         <RemoveButton integrationType="gohighlevel" label="GoHighLevel" />
                       </>
                     ) : (
@@ -514,6 +519,12 @@ function SettingsPageContent() {
                   <div className="flex items-center gap-2 flex-wrap">
                     {facebookStatus.connected ? (
                       <>
+                        {facebookStatus.token_expired && (
+                          <Button size="sm" variant="destructive" onClick={() => handleConnect("facebook")} disabled={isLoading}>
+                            {isLoading && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+                            Reconnect
+                          </Button>
+                        )}
                         <RemoveButton integrationType="facebook" label="Meta (Facebook)" />
                       </>
                     ) : (

--- a/src/components/campaigns/MarketingContent.jsx
+++ b/src/components/campaigns/MarketingContent.jsx
@@ -717,6 +717,39 @@ export function MarketingContent({
         </div>
         )}
 
+        {/* Meta reconnect banner — shown on API error OR when any group has a token error flag */}
+        {(() => {
+          const hasTokenError = clientGroups.some(g => g.meta_token_error)
+          const errorText = groupsError || ""
+          const isMetaAuth = hasTokenError ||
+            errorText.toLowerCase().includes("permission") ||
+            errorText.toLowerCase().includes("token") ||
+            errorText.toLowerCase().includes("403")
+          const showBanner = groupsError || hasTokenError
+
+          if (!showBanner) return null
+          return (
+            <div className="flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3">
+              <div className="flex items-center gap-2 text-sm text-amber-800">
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+                </svg>
+                <span>
+                  {isMetaAuth
+                    ? "Your Meta connection has expired or lost permissions. Please reconnect to continue seeing campaign data."
+                    : `Failed to load campaign data: ${errorText}`}
+                </span>
+              </div>
+              <a
+                href="/settings?tab=integrations"
+                className="shrink-0 rounded-md bg-amber-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-700 transition-colors"
+              >
+                {isMetaAuth ? "Reconnect Meta" : "Go to Settings"}
+              </a>
+            </div>
+          )
+        })()}
+
         {/* Summary cards */}
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
           {[

--- a/src/lib/useClientGroups.js
+++ b/src/lib/useClientGroups.js
@@ -41,7 +41,17 @@ export function useClientGroups(initialPreset = DEFAULT_DATE_PRESET) {
         `/api/client-groups?date_preset=${preset}`,
         { signal: controller.signal }
       )
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      if (!res.ok) {
+        // Try to extract a meaningful error message from the response
+        let detail = `HTTP ${res.status}`
+        try {
+          const body = await res.json()
+          detail = body.detail || body.error || detail
+        } catch {}
+        const err = new Error(detail)
+        err.status = res.status
+        throw err
+      }
 
       const data = await res.json()
       const groups = data.client_groups || []


### PR DESCRIPTION
- Separate custom metric evaluation from campaign processing via useMemo to eliminate race condition with async metrics API load
- Add amber reconnect banner on Marketing Hub when Meta token expires
- Add Reconnect button on Settings page for expired Meta/GHL tokens
- Improve useClientGroups error to surface backend error details