### PR TITLE
fix: suppress Unknown Ad Account meta name, fallback to group name

### DIFF
--- a/src/components/integrations/IntegrationsContent.jsx
+++ b/src/components/integrations/IntegrationsContent.jsx
@@ -250,7 +250,12 @@ export default function IntegrationsContent({ group, onRefreshComplete }) {
         icon={metaIcon}
         connected={metaConnected}
         details={[
-          { label: "Account", value: group.facebook?.name || "—" },
+          { 
+            label: "Account", 
+            value: (group.facebook?.name && group.facebook.name !== "Unknown Ad Account")
+              ? group.facebook.name 
+              : group.name
+          },
           { label: "Account ID", value: group.facebook?.ad_account_id || group.meta_ad_account_id || "—" },
           { label: "Currency", value: group.facebook?.currency || group.ad_account_currency || "—" },
         ]}


### PR DESCRIPTION
<img width="1917" height="916" alt="image" src="https://github.com/user-attachments/assets/ed16dfe9-cacf-4dec-8fc6-475b778c19e5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Meta Ads integration account display. The account information field now shows more relevant account names by intelligently prioritizing primary identifiers when available and gracefully handling cases where account names may be unavailable, ensuring users always see the most appropriate account reference.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nova-sudo/birdy-beta/pull/71)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->