### PR TITLE
fix: truncate first column name with hover tooltip for full name

### DIFF
--- a/src/components/ui/table-container.jsx
+++ b/src/components/ui/table-container.jsx
@@ -832,28 +832,20 @@ const StyledTable = ({
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <span
-                                  className={`truncate min-w-0 flex items-center justify-between gap-2 w-full ${
+                                  className={`min-w-0 flex items-center gap-2 w-full overflow-hidden ${
                                     row._isCreating || row._isPending ? "text-muted-foreground" : ""
                                   }`}
                                 >
                                   {colIdx === 0 && clickableFirstColumn && !onRowClick ? (
                                     <button
                                       onClick={() => onFirstColumnClick?.(row)}
-                                      className="text-left font-semibold text-primary hover:underline cursor-pointer w-full"
+                                      className="text-left font-semibold text-primary hover:underline cursor-pointer truncate min-w-0"
                                     >
                                       {col.cell ? col.cell(row[col.id], row) : getCellValue(row, col.id)}
                                     </button>
                                   ) : (
-                                    col.cell ? col.cell(row[col.id], row) : getCellValue(row, col.id)
-                                  )}
-
-                                  {colIdx === 0 && isRowLoading?.(row) && (
-                                    <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground whitespace-nowrap shrink-0">
-                                      <svg className="animate-spin h-3 w-3 shrink-0" viewBox="0 0 24 24" fill="none">
-                                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-                                      </svg>
-                                      Setting up…
+                                    <span className="truncate min-w-0 block">
+                                      {col.cell ? col.cell(row[col.id], row) : getCellValue(row, col.id)}
                                     </span>
                                   )}
 
@@ -904,9 +896,9 @@ const StyledTable = ({
                                   )}
                                 </span>
                               </TooltipTrigger>
-                              {colIdx === 0 && !col.cell && (
+                              {colIdx === 0 && (
                                 <TooltipContent>
-                                  <p>{getCellValue(row, col.id)}</p>
+                                  <p>{col.cell ? col.cell(row[col.id], row) : getCellValue(row, col.id)}</p>
                                 </TooltipContent>
                               )}
                             </Tooltip>


### PR DESCRIPTION
<img width="817" height="717" alt="image" src="https://github.com/user-attachments/assets/37bd35ed-c261-42a3-8169-842e2cfbc5ea" />
<img width="395" height="656" alt="image" src="https://github.com/user-attachments/assets/f23d6a0a-902b-492d-8213-de28418ae6bd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip rendering and content display in the table's first column.
  * Enhanced cell layout and text truncation handling for better visibility in the first column.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nova-sudo/birdy-beta/pull/72)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->