### PR TITLE
fix: show status badge on clients page only and remove it from marketing page

### DIFF
--- a/src/components/ui/table-container.jsx
+++ b/src/components/ui/table-container.jsx
@@ -858,9 +858,8 @@ const StyledTable = ({
                                   )}
 
                                   {/* ── Read-only badge (isClientMode) OR clickable badge (!isClientMode) ── */}
-                                  {colIdx === 0 && !isRowLoading?.(row) && row.status && (
-                                    isClientMode ? (
-                                      /* Read-only badge for client hub */
+                                  {/* ── Read-only status badge — clients page only ── */}
+                                    {colIdx === 0 && isClientMode && !isRowLoading?.(row) && row.status && (
                                       <span
                                         className={`ml-auto shrink-0 inline-flex items-center gap-1.5 text-[11px] font-medium px-2.5 py-[3px] rounded-full select-none ${
                                           isActive
@@ -873,35 +872,7 @@ const StyledTable = ({
                                         }`} />
                                         <span className="hidden sm:inline">{row.status}</span>
                                       </span>
-                                    ) : (
-                                      /* Clickable badge for non-client tables */
-                                      <button
-                                        onClick={(e) => {
-                                          e.stopPropagation()
-                                          onStatusToggle?.(row.id, row.status)
-                                        }}
-                                        disabled={isToggling}
-                                        title={`Click to toggle status (currently ${row.status || "Active"})`}
-                                        className={`ml-auto shrink-0 inline-flex items-center gap-1 text-[11px] font-medium px-2 py-[3px] rounded-full transition-all cursor-pointer ${
-                                          isActive
-                                            ? "bg-[#DCFCE7] text-[#15803D] hover:bg-[#DCFCE7]/70"
-                                            : "bg-[#FEF9C3] text-[#A16207] hover:bg-[#FEF9C3]/70"
-                                        } disabled:opacity-50 disabled:cursor-not-allowed`}
-                                      >
-                                        {isToggling ? (
-                                          <svg className="animate-spin h-3 w-3 shrink-0" viewBox="0 0 24 24" fill="none">
-                                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-                                          </svg>
-                                        ) : (
-                                          <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${
-                                            isActive ? "bg-[#15803D]" : "bg-[#A16207]"
-                                          }`} />
-                                        )}
-                                        <span className="hidden sm:inline">{row.status || "Active"}</span>
-                                      </button>
-                                    )
-                                  )}
+                                    )}
                                 </span>
                               </TooltipTrigger>
                               {colIdx === 0 && !col.cell && (


### PR DESCRIPTION
<img width="1917" height="952" alt="image" src="https://github.com/user-attachments/assets/59c34865-1828-4c04-8565-80593d473798" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Clarified status badge behavior: client pages show read-only badges (hidden when loading or unset) and other tables retain a clickable status toggle with proper disabled/loading visuals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nova-sudo/birdy-beta/pull/76)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nova-sudo/birdy-beta/pull/76)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->