### PR TITLE
Per-client call log provider + 30-day session TTL

### DIFF
--- a/src/app/Sales-Hub/page.jsx
+++ b/src/app/Sales-Hub/page.jsx
@@ -17,7 +17,11 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
 import { Alert, AlertDescription } from "@/components/ui/alert"
+import { apiRequest } from "@/lib/api"
+import { useClientGroups } from "@/lib/useClientGroups"
+import { DEFAULT_DATE_PRESET } from "@/lib/constants"
 import {
   Users,
   Phone,
@@ -236,10 +240,47 @@ export default function CallCenterPage() {
   const [leadsPerPage] = useState(100)
   const [locationStats, setLocationStats] = useState({})
 
-  // Fetch leads on mount
+  // ── Per-client routing ───────────────────────────────────────────────────
+  // Sales-Hub data is now scoped to one client at a time. The selected
+  // client's call_log_provider field decides whether we read from the new
+  // call_logs collection (GHL) or short-circuit to an empty/coming-soon
+  // state (HotProspector — endpoints not ready yet).
+  const { clientGroups, loading: clientGroupsLoading } = useClientGroups(DEFAULT_DATE_PRESET)
+  const [selectedGroupId, setSelectedGroupId] = useState(null)
+  const [providerComingSoon, setProviderComingSoon] = useState(false)
+
+  // Default-select the first client once they load (or restore from session).
   useEffect(() => {
-    fetchAllLeads()
+    if (clientGroupsLoading) return
+    if (!clientGroups || clientGroups.length === 0) return
+    if (selectedGroupId && clientGroups.some((g) => g.id === selectedGroupId)) return
+    const remembered = (typeof window !== "undefined") ? sessionStorage.getItem("salesHub.selectedGroupId") : null
+    const fallback = clientGroups.find((g) => g.id === remembered)?.id || clientGroups[0].id
+    setSelectedGroupId(fallback)
+  }, [clientGroups, clientGroupsLoading, selectedGroupId])
+
+  // Persist selection so the page survives a refresh.
+  useEffect(() => {
+    if (selectedGroupId && typeof window !== "undefined") {
+      sessionStorage.setItem("salesHub.selectedGroupId", selectedGroupId)
+    }
+  }, [selectedGroupId])
+
+  const selectedGroup = (clientGroups || []).find((g) => g.id === selectedGroupId) || null
+  const selectedProvider = (selectedGroup?.call_log_provider || "ghl").toLowerCase()
+
+  // Re-fetch whenever the selected client changes.
+  useEffect(() => {
+    if (!selectedGroupId) return
+    fetchAllLeads(1)
+    // members data is still HP-mock for now — leave alone
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedGroupId])
+
+  // Fetch members on mount (mock data — independent of provider for now).
+  useEffect(() => {
     fetchMembers()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {
@@ -255,45 +296,109 @@ export default function CallCenterPage() {
 
 
 
-  // Demo mode: pulls from src/app/Sales-Hub/mockData.js — no API calls.
-  // The data shape mirrors the real /api/hotprospector/leads response so all
-  // the existing tables, dialogs, columns, pagination and search work
-  // unchanged. Swap mockFetchLeads → apiRequest("/api/hotprospector/leads…")
-  // when the integration comes back online.
+  // Provider-aware fetch.
+  //   - hotprospector → empty + coming-soon flag (endpoints not ready)
+  //   - ghl          → GET /api/call_logs?group_id=… → flat call rows that we
+  //                    group by contact so the existing leads/CallLogsDialog
+  //                    UI keeps working unchanged.
   const fetchAllLeads = async (page = 1, _forceRefresh = false) => {
+    if (!selectedGroupId) {
+      setLeads([])
+      setTotalLeads(0)
+      setLocationStats({})
+      return
+    }
+
+    const group = (clientGroups || []).find((g) => g.id === selectedGroupId)
+    if (!group) return
+
+    const provider = (group.call_log_provider || "ghl").toLowerCase()
+
+    // HotProspector short-circuit — show coming-soon, no data fetch.
+    if (provider === "hotprospector") {
+      setProviderComingSoon(true)
+      setLeads([])
+      setTotalLeads(0)
+      setLocationStats({})
+      setCurrentPage(1)
+      setIsLoading(false)
+      setIsRefreshing(false)
+      return
+    }
+
+    setProviderComingSoon(false)
+
     try {
       setIsLoading(true)
       setError(null)
 
       const skip = (page - 1) * leadsPerPage
-      const data = await mockFetchLeads({ skip, limit: leadsPerPage })
+      const res = await apiRequest(
+        `/api/call_logs?group_id=${encodeURIComponent(selectedGroupId)}&skip=${skip}&limit=${leadsPerPage}`
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.detail || `HTTP ${res.status}`)
+      }
+      const data = await res.json()
 
-      const mappedLeads = (data.data || []).map((lead) => ({
-        id: lead.id,
-        client: lead.client_name || "Unknown Client",
-        ghlLocation: lead.ghl_location_name || "Unknown Location",
-        ghlLocationId: lead.ghl_location_id,
-        name: `${lead.first_name || ""} ${lead.last_name || ""}`.trim() || "N/A",
-        email: lead.email || "N/A",
-        phone:
-          lead.phone || lead.mobile
-            ? `${lead.country_code || ""}${lead.mobile || lead.phone || ""}`.trim()
-            : "N/A",
-        company: lead.company || "N/A",
-        location: [lead.city, lead.state, lead.country_code].filter(Boolean).join(", ") || "N/A",
-        tags: lead.tags || [],
-        status: "Active",
-        call_logs_count: lead.call_logs_count || 0,
-        call_logs: lead.call_logs || [],
-      }))
+      // Group flat GHL call rows by contact (id, then phone fallback) so each
+      // row in the existing table represents one contact with all their calls
+      // nested — matching the HP-shaped UI the page was built for.
+      const byContact = new Map()
+      for (const log of data.data || []) {
+        const key = log.contact_id || log.contact_phone || `unknown_${log.id}`
+        if (!byContact.has(key)) {
+          byContact.set(key, {
+            id: key,
+            client: group.name || "Unknown Client",
+            ghlLocation: group.name || "Unknown Location",
+            ghlLocationId: log.location_id,
+            name: log.contact_id || log.contact_phone || "—",
+            email: log.contact_email || "N/A",
+            phone: log.contact_phone || "N/A",
+            company: "N/A",
+            location: "N/A",
+            tags: [],
+            status: "Active",
+            call_logs_count: 0,
+            call_logs: [],
+          })
+        }
+        const lead = byContact.get(key)
+        const isOutbound = (log.direction || "").toLowerCase() === "outbound"
+        lead.call_logs.push({
+          call_time: log.started_at,
+          call_status: log.direction,
+          duration: log.duration_seconds || 0,
+          speed_to_lead: 0,
+          from_number: isOutbound ? "" : (log.contact_phone || ""),
+          to_number: isOutbound ? (log.contact_phone || "") : "",
+          recording_url: log.recording_url,
+          caller_name: log.contact_id || log.contact_phone || "Unknown",
+          group: group.name || "",
+          location_name: group.name || "",
+          transfer: false,
+        })
+        lead.call_logs_count += 1
+      }
+
+      const mappedLeads = Array.from(byContact.values())
 
       setLeads(mappedLeads)
-      setTotalLeads(data.meta?.total || 0)
+      setTotalLeads(data.meta?.total ?? mappedLeads.length)
       setCurrentPage(page)
-      setLocationStats(data.meta?.location_stats || {})
+      setLocationStats({
+        [group.ghl_location_id || group.id]: {
+          name: group.name,
+          count: mappedLeads.length,
+        },
+      })
     } catch (err) {
-      console.error("Error loading mock leads:", err)
-      setError(err.message)
+      console.error("Error loading call logs:", err)
+      setError(err?.message || "Failed to load call logs")
+      setLeads([])
+      setTotalLeads(0)
     } finally {
       setIsLoading(false)
       setIsRefreshing(false)
@@ -374,14 +479,6 @@ export default function CallCenterPage() {
 
   return (
     <div className="w-[calc(100dvw-70px)] md:w-[calc(100dvw-130px)]">
-      {/* Demo mode banner — make it obvious nothing is wired to real data */}
-      <div className="mb-4 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50/80 px-4 py-2 text-sm text-amber-800">
-        <Construction className="h-4 w-4 shrink-0" />
-        <span>
-          <span className="font-semibold">Demo data.</span>{" "}
-          Sales Hub is showing mock leads & members while the HotProspector integration is offline.
-        </span>
-      </div>
       <div>
         <div>
           <div className="">
@@ -391,8 +488,38 @@ export default function CallCenterPage() {
                 <div>
                   <h1 className="text-xl md:text-3xl lg:text-3xl py-2 md:py-0 font-bold text-foreground text-center md:text-left whitespace-nowrap">Sales Hub</h1>
                   <p className="text-sm text-muted-foreground mt-1 text-center md:text-left">
-                    Manage leads and team members from HotProspector
+                    {selectedGroup
+                      ? <>Call logs for <span className="font-medium text-foreground">{selectedGroup.name}</span> &middot; provider: <span className="font-medium text-foreground">{selectedProvider === "hotprospector" ? "Hot Prospector" : "GoHighLevel"}</span></>
+                      : "Pick a client to view their call logs"}
                   </p>
+                </div>
+                {/* Per-client picker — decides which data source we read */}
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-muted-foreground hidden md:inline">Client:</span>
+                  <Select
+                    value={selectedGroupId || ""}
+                    onValueChange={(v) => setSelectedGroupId(v)}
+                    disabled={clientGroupsLoading || !clientGroups || clientGroups.length === 0}
+                  >
+                    <SelectTrigger className="bg-white h-10 min-w-[220px]">
+                      <SelectValue placeholder={clientGroupsLoading ? "Loading clients…" : "Pick a client"} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(clientGroups || []).map((g) => {
+                        const p = (g.call_log_provider || "ghl").toLowerCase()
+                        return (
+                          <SelectItem key={g.id} value={g.id}>
+                            <span className="flex items-center gap-2">
+                              <span>{g.name}</span>
+                              <span className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 border border-border text-muted-foreground">
+                                {p === "hotprospector" ? "HP" : "GHL"}
+                              </span>
+                            </span>
+                          </SelectItem>
+                        )
+                      })}
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
 
@@ -459,6 +586,24 @@ export default function CallCenterPage() {
 
         <div>
           <div className="bg-card rounded-lg mt-6 mb-12 ">
+            {/* Hot Prospector coming-soon placeholder for HP-provider clients */}
+            {providerComingSoon && (
+              <div className="my-4 p-10 rounded-xl border-2 border-dashed border-amber-200 bg-amber-50/60 text-center">
+                <div className="w-16 h-16 mx-auto rounded-full bg-amber-100 flex items-center justify-center mb-4">
+                  <Construction className="w-8 h-8 text-amber-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-foreground mb-2">Hot Prospector &mdash; Coming Soon</h2>
+                <p className="text-muted-foreground max-w-md mx-auto">
+                  This client&apos;s call logs are configured to come from <span className="font-medium">Hot Prospector</span>.
+                  The HP integration is still in progress &mdash; call data will appear here once their endpoints are wired up.
+                </p>
+                {selectedGroup && (
+                  <p className="text-xs text-muted-foreground mt-4">
+                    Selected client: <span className="font-medium text-foreground">{selectedGroup.name}</span>
+                  </p>
+                )}
+              </div>
+            )}
             {/* Stats Cards */}
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
               <Card className="border rounded-lg shadow-sm ">
@@ -541,7 +686,9 @@ export default function CallCenterPage() {
                   <div className="text-center py-12 border-2 border-dashed rounded-lg">
                     <Phone className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
                     <p className="text-muted-foreground">
-                      No leads found. Make sure you have HotProspector connected and GHL locations configured.
+                      {selectedGroup
+                        ? <>No call logs yet for <span className="font-medium">{selectedGroup.name}</span>. Once a call event fires through the GHL workflow webhook, it&apos;ll appear here.</>
+                        : "Pick a client above to view their call logs."}
                     </p>
                     <Button
                       variant="outline"

--- a/src/app/clients/page.jsx
+++ b/src/app/clients/page.jsx
@@ -1,5 +1,5 @@
 "use client"
-import { useEffect, useState, useMemo } from "react"
+import { Fragment, useEffect, useState, useMemo } from "react"
 import { useRouter } from "next/navigation"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -16,7 +16,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-import { Building2, Plus, Check, ChevronRight, Users, DollarSign, UserCheck, Target, Search } from "lucide-react"
+import { ArrowLeft, ArrowRight, Building2, Plus, Check, ChevronRight, Users, DollarSign, UserCheck, Target, Search } from "lucide-react"
 import { toast } from "sonner"
 import { Input } from "@/components/ui/input"
 import { useColumnViews } from "@/lib/useColumnViews"
@@ -98,6 +98,12 @@ export default function ClientsPage() {
   const [metaSearchQuery, setMetaSearchQuery] = useState("")
   const [hotProspectorSearchQuery, setHotProspectorSearchQuery] = useState("")
   const [addingClientGroup, setAddingClientGroup] = useState(false)
+  // ── Step 4: call log provider ────────────────────────────────────────────
+  const [callLogProvider, setCallLogProvider] = useState(null) // null | "ghl" | "hotprospector"
+  const [hpApiUid, setHpApiUid] = useState("")
+  const [hpApiKey, setHpApiKey] = useState("")
+  const [hpTestStatus, setHpTestStatus] = useState("idle") // "idle" | "testing" | "success" | "error"
+  const [hpTestError, setHpTestError] = useState("")
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [togglingRows, setTogglingRows] = useState(new Set())
 
@@ -394,6 +400,29 @@ export default function ClientsPage() {
     }
   }
 
+  const testHotProspectorConnection = async () => {
+    if (!hpApiUid || !hpApiKey) return
+    setHpTestStatus("testing")
+    setHpTestError("")
+    try {
+      const res = await apiRequest("/api/hotprospector/connect", {
+        method: "POST",
+        body: JSON.stringify({ api_uid: hpApiUid, api_key: hpApiKey }),
+      })
+      if (res.ok) {
+        setHpTestStatus("success")
+        toast.success("Hot Prospector connected")
+      } else {
+        const data = await res.json().catch(() => ({}))
+        setHpTestStatus("error")
+        setHpTestError(data.detail || "Invalid credentials")
+      }
+    } catch (err) {
+      setHpTestStatus("error")
+      setHpTestError(err?.message || "Connection failed")
+    }
+  }
+
   const handleCreateClientGroup = async () => {
     if (!clientGroupName) {
       toast.error("Please enter a client group name")
@@ -407,8 +436,12 @@ export default function ClientsPage() {
       toast.error("Please select a Meta ad account or skip this step")
       return
     }
+    if (wizardStep === 4 && !callLogProvider) {
+      toast.error("Please choose a call log provider (GoHighLevel or Hot Prospector)")
+      return
+    }
 
-    if (wizardStep < 3) {
+    if (wizardStep < 4) {
       setWizardStep(wizardStep + 1)
       return
     }
@@ -442,6 +475,11 @@ export default function ClientsPage() {
     setLocationSearchQuery("")
     setMetaSearchQuery("")
     setHotProspectorSearchQuery("")
+    setCallLogProvider(null)
+    setHpApiUid("")
+    setHpApiKey("")
+    setHpTestStatus("idle")
+    setHpTestError("")
 
     toast.info(`Creating "${creatingGroupName}"...`)
 
@@ -460,6 +498,7 @@ export default function ClientsPage() {
           meta_ad_account_id: selectedMetaAdAccount?.id || null,
           hotprospector_group_id: selectedHotProspectorGroup?.id || null,
           ad_account_currency: selectedMetaAdAccount?.currency || null,
+          call_log_provider: callLogProvider || "ghl",
           notes: "",
         }),
       });
@@ -640,50 +679,104 @@ export default function ClientsPage() {
             setLocationSearchQuery("")
             setMetaSearchQuery("")
             setHotProspectorSearchQuery("")
+            setCallLogProvider(null)
+            setHpApiUid("")
+            setHpApiKey("")
+            setHpTestStatus("idle")
+            setHpTestError("")
           }
         }}
       >
-        {/* Add client */}
-        <DialogContent className="sm:max-w-2xl bg-zinc-50 p-0 overflow-hidden border-0 shadow-2xl">
-          <DialogHeader className="bg-gradient-to-r from-purple-600 to-purple-700 px-6 py-5">
-            <div className="flex items-center gap-3">
-              <div className="bg-white/20 p-2 rounded-lg">
-                <Building2 className="w-5 h-5 text-white" />
-              </div>
-              <div>
-                <DialogTitle className="text-xl font-semibold text-white">Client Linking Wizard</DialogTitle>
-                <p className="text-purple-100 text-sm">
-                  Step {wizardStep} of 3:{" "}
-                  {
-                    [
-                      "Name your client group",
-                      "Select or add GHL subaccount",
-                      "Select Meta ad account",
-                      "Select Hot Prospector group",
-                    ][wizardStep - 1]
-                  }
-                </p>
-              </div>
-            </div>
+        <DialogContent className="sm:max-w-2xl max-h-[95vh] overflow-y-auto overflow-x-hidden p-4 md:p-6">
+          {/* sr-only title so Radix Dialog has accessible labelling */}
+          <DialogHeader className="sr-only">
+            <DialogTitle>Birdy Linking Wizard</DialogTitle>
           </DialogHeader>
-          <div className="h-auto bg-white">
-            {wizardStep === 1 && (
-              <div className="space-y-2 p-2">
-                <div>
-                  <label className="text-sm font-medium text-foreground">Client Group Name</label>
-                  <Input
-                    type="text"
-                    placeholder="Enter client group name"
-                    value={clientGroupName}
-                    onChange={(e) => setClientGroupName(e.target.value)}
-                    className="mt-1"
-                    autoFocus
-                  />
+
+          <div className="w-full py-2">
+            <div className="w-full max-w-xl mx-auto space-y-6 flex flex-col">
+              {/* ── Top stepper (responsive) ────────────────────── */}
+              <div className="w-full overflow-hidden">
+                <div className="flex items-start gap-1 sm:gap-2 w-full">
+                  {[
+                    { num: 1, short: "Name", full: "Client Name" },
+                    { num: 2, short: "GHL", full: "GHL" },
+                    { num: 3, short: "Meta", full: "Meta" },
+                    { num: 4, short: "Calls", full: "Sales Calls" },
+                  ].map((s, i, arr) => (
+                    <Fragment key={s.num}>
+                      <div className="flex flex-col items-center flex-shrink-0">
+                        <div
+                          className={`w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center text-xs sm:text-sm font-medium transition-all duration-300 ${wizardStep > s.num
+                            ? "stepper-completed"
+                            : wizardStep === s.num
+                              ? "stepper-active"
+                              : "stepper-pending"
+                            }`}
+                        >
+                          {wizardStep > s.num
+                            ? <Check className="w-4 h-4 sm:w-5 sm:h-5" />
+                            : <span>{s.num}</span>}
+                        </div>
+                        <div className="mt-2 text-center px-1">
+                          <div
+                            className={`text-[10px] sm:text-xs md:text-sm font-medium transition-colors whitespace-nowrap ${wizardStep > s.num
+                              ? "text-success"
+                              : wizardStep === s.num
+                                ? "text-primary"
+                                : "text-muted-foreground"
+                              }`}
+                          >
+                            <span className="sm:hidden">{s.short}</span>
+                            <span className="hidden sm:inline">{s.full}</span>
+                          </div>
+                        </div>
+                      </div>
+                      {i < arr.length - 1 && (
+                        <div className="flex-1 min-w-[8px] mt-[14px] sm:mt-5">
+                          <div
+                            className={`h-0.5 rounded-full transition-all duration-500 ${wizardStep > s.num ? "bg-success" : "bg-border"
+                              }`}
+                          />
+                        </div>
+                      )}
+                    </Fragment>
+                  ))}
                 </div>
               </div>
-            )}
+
+              {/* ── Card-wrapped step content ──────────────────── */}
+              <div
+                key={wizardStep}
+                className="rounded-lg bg-card text-card-foreground card-gradient border-0 shadow-card animate-slide-in"
+              >
+                <div className="p-6 md:p-8 space-y-6">
+                  {/* === Step 1: Client name === */}
+                  {wizardStep === 1 && (
+                    <div className="max-w-md mx-auto space-y-4">
+                      <div className="text-center space-y-2">
+                        <h2 className="text-2xl font-bold text-foreground">Name your client group</h2>
+                        <p className="text-muted-foreground">A short label you'll use to find this client later.</p>
+                      </div>
+                      <div className="space-y-2 text-left">
+                        <label className="text-sm font-medium leading-none" htmlFor="client-group-name">Client Group Name</label>
+                        <Input
+                          id="client-group-name"
+                          type="text"
+                          placeholder="e.g. Acme Dental"
+                          value={clientGroupName}
+                          onChange={(e) => setClientGroupName(e.target.value)}
+                          autoFocus
+                        />
+                      </div>
+                    </div>
+                  )}
             {wizardStep === 2 && (
-              <div className="space-y-4 p-4 ">
+              <div className="space-y-4">
+                <div className="text-center space-y-2">
+                  <h2 className="text-2xl font-bold text-foreground">Link a GoHighLevel subaccount</h2>
+                  <p className="text-muted-foreground">Pick the GHL location for this client&apos;s contacts &amp; opportunities.</p>
+                </div>
                 <div className="relative">
                   <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4  " />
                   <Input
@@ -721,7 +814,7 @@ export default function ClientsPage() {
                               </h3>
                             </div>
                             <p
-                              className={`text-xs font-mono ${selectedGhlLocation?.locationId === location.locationId
+                              className={`text-xs font-mono truncate ${selectedGhlLocation?.locationId === location.locationId
                                 ? "text-purple-600"
                                 : "text-muted-foreground"
                                 }`}
@@ -773,8 +866,12 @@ export default function ClientsPage() {
               </div>
             )}
             {wizardStep === 3 && (
-              <div className="space-y-2 p-4">
-                <div className="relative ">
+              <div className="space-y-4">
+                <div className="text-center space-y-2">
+                  <h2 className="text-2xl font-bold text-foreground">Link a Meta ad account</h2>
+                  <p className="text-muted-foreground">Pick the ad account for this client&apos;s campaigns &amp; spend.</p>
+                </div>
+                <div className="relative">
                   <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
                   <Input
                     type="text"
@@ -808,7 +905,7 @@ export default function ClientsPage() {
                               </h3>
                             </div>
                             <p
-                              className={`text-xs font-mono ${selectedMetaAdAccount?.id === account.id
+                              className={`text-xs font-mono truncate ${selectedMetaAdAccount?.id === account.id
                                 ? "text-purple-600"
                                 : "text-muted-foreground"
                                 }`}
@@ -859,127 +956,162 @@ export default function ClientsPage() {
                 )}
               </div>
             )}
-            {/* {wizardStep === 4 && (
-                      <div className="space-y-4">
-                        <div className="relative">
-                          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
-                          <Input
-                            type="text"
-                            placeholder="Search Hot Prospector groups by name or ID..."
-                            value={hotProspectorSearchQuery}
-                            onChange={(e) => setHotProspectorSearchQuery(e.target.value)}
-                            className="pl-10 pr-4 py-3"
-                          />
-                        </div>
-                        <div className="space-y-2 max-h-80 overflow-y-auto">
-                          {filteredHotProspectorGroups.length > 0 ? (
-                            filteredHotProspectorGroups.map((group) => (
-                              <div
-                                key={group.id}
-                                onClick={() => setSelectedHotProspectorGroup(group)}
-                                className={`relative p-4 rounded-xl border-2 cursor-pointer transition-all duration-200 hover:shadow-md group ${
-                                  selectedHotProspectorGroup?.id === group.id
-                                    ? "border-purple-500 bg-purple-50 shadow-md"
-                                    : "border-border hover:border-muted-foreground bg-card"
-                                }`}
-                              >
-                                <div className="flex items-start justify-between">
-                                  <div className="flex-1 min-w-0">
-                                    <div className="flex items-center gap-2 mb-2">
-                                      <h3
-                                        className={`font-semibold truncate ${
-                                          selectedHotProspectorGroup?.id === group.id
-                                            ? "text-purple-900"
-                                            : "text-foreground"
-                                        }`}
-                                      >
-                                        {group.name || "Unnamed Group"}
-                                      </h3>
-                                    </div>
-                                    <p
-                                      className={`text-xs font-mono ${
-                                        selectedHotProspectorGroup?.id === group.id
-                                          ? "text-purple-600"
-                                          : "text-muted-foreground"
-                                      }`}
-                                    >
-                                      ID: {group.id}
-                                    </p>
-                                  </div>
-                                  <div
-                                    className={`ml-3 flex-shrink-0 w-5 h-5 rounded-full border-2 flex items-center justify-center transition-all duration-200 ${
-                                      selectedHotProspectorGroup?.id === group.id
-                                        ? "bg-purple-600 border-purple-600"
-                                        : "border-border group-hover:border-muted-foreground"
-                                    }`}
-                                  >
-                                    {selectedHotProspectorGroup?.id === group.id && (
-                                      <Check className="w-3 h-3 text-white" />
-                                    )}
-                                  </div>
-                                </div>
-                              </div>
-                            ))
-                          ) : (
-                            <div className="text-center py-12 text-muted-foreground">
-                              <Building2 className="w-12 h-12 mx-auto mb-3 text-muted" />
-                              <p>No Hot Prospector groups found</p>
-                              <p className="text-sm">Try adjusting your search terms</p>
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    )} */}
-          </div>
-          <div className="bg-muted/50 p-4 flex items-center justify-between border-t border-border">
-            <p className="text-sm text-muted-foreground">
-              {wizardStep === 2 &&
-                `${filteredGhlLocations.length} location${filteredGhlLocations.length !== 1 ? "s" : ""} available`}
-              {wizardStep === 3 &&
-                `${filteredMetaAdAccounts.length} ad account${filteredMetaAdAccounts.length !== 1 ? "s" : ""} available`}
-              {/* {wizardStep === 4 &&
-                        `${filteredHotProspectorGroups.length} group${filteredHotProspectorGroups.length !== 1 ? "s" : ""} available`} */}
-            </p>
-            <div className="flex items-center ">
-              {wizardStep > 1 && (
-                <Button
-                  variant="ghost"
-                  onClick={() => setWizardStep(wizardStep - 1)}
-                  className="text-muted-foreground hover:bg-muted"
-                >
-                  Back
-                </Button>
-              )}
-              <Button
-                variant="ghost"
-                onClick={() => setWizardOpen(false)}
-                disabled={addingClientGroup}
-                className="text-muted-foreground hover:bg-muted"
-              >
-                Cancel
-              </Button>
-              <Button
-                onClick={handleCreateClientGroup}
-                disabled={addingClientGroup || (wizardStep === 1 && !clientGroupName)}
-                className="bg-purple-600 hover:bg-purple-700 text-white min-w-[120px]"
-              >
-                {addingClientGroup ? (
+            {/* === Step 4: Call log provider === */}
+            {wizardStep === 4 && (
+              <div className="max-w-md mx-auto space-y-6">
+                {!callLogProvider && (
                   <>
-                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2" />
-                    Creating...
-                  </>
-                ) : wizardStep < 3 ? (
-                  <>
-                    <ChevronRight className="w-4 h-4 mr-2" />
-                    Next
-                  </>
-                ) : (
-                  <>
-                    <Plus className="w-4 h-4 mr-2" />
-                    Create Client Group
+                    <div className="text-center space-y-2">
+                      <h2 className="text-2xl font-bold text-foreground">Where do calls come from?</h2>
+                      <p className="text-muted-foreground">Pick which provider feeds this client&apos;s Sales Hub call logs.</p>
+                    </div>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                      <button
+                        type="button"
+                        onClick={() => setCallLogProvider("ghl")}
+                        className="p-5 rounded-xl border-2 border-border hover:border-primary hover:bg-primary/5 transition-colors text-left"
+                      >
+                        <div className="font-semibold text-foreground mb-1">GoHighLevel</div>
+                        <div className="text-xs text-muted-foreground">Uses your GHL workflow webhook.</div>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setCallLogProvider("hotprospector")}
+                        className="p-5 rounded-xl border-2 border-border hover:border-primary hover:bg-primary/5 transition-colors text-left"
+                      >
+                        <div className="font-semibold text-foreground mb-1">Hot Prospector</div>
+                        <div className="text-xs text-muted-foreground">Coming soon &mdash; credentials saved now.</div>
+                      </button>
+                    </div>
                   </>
                 )}
-              </Button>
+
+                {callLogProvider === "ghl" && (
+                  <>
+                    <div className="text-center space-y-2">
+                      <h2 className="text-2xl font-bold text-foreground">Using GoHighLevel</h2>
+                      <p className="text-muted-foreground">Calls will arrive via your GHL workflow webhook on the linked subaccount.</p>
+                    </div>
+                    <div className="p-4 rounded-xl bg-success/10 border border-success/20 flex items-center gap-3">
+                      <Check className="w-5 h-5 text-success shrink-0" />
+                      <span className="text-sm text-foreground">Ready &mdash; no extra setup needed at this step.</span>
+                    </div>
+                    <div className="text-center">
+                      <button
+                        type="button"
+                        onClick={() => setCallLogProvider(null)}
+                        className="text-sm text-muted-foreground hover:text-foreground underline-offset-4 hover:underline"
+                      >
+                        Change provider
+                      </button>
+                    </div>
+                  </>
+                )}
+
+                {callLogProvider === "hotprospector" && (
+                  <>
+                    <div className="text-center space-y-2">
+                      <h2 className="text-2xl font-bold text-foreground">Connect Hot Prospector</h2>
+                      <p className="text-muted-foreground">Enter your Hot Prospector API credentials.</p>
+                    </div>
+                    <div className="space-y-4 text-left">
+                      <div className="space-y-2">
+                        <label className="text-sm font-medium leading-none" htmlFor="hp-api-uid">API UID</label>
+                        <Input
+                          id="hp-api-uid"
+                          type="text"
+                          placeholder="Enter your API UID"
+                          value={hpApiUid}
+                          onChange={(e) => { setHpApiUid(e.target.value); setHpTestStatus("idle") }}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <label className="text-sm font-medium leading-none" htmlFor="hp-api-key">API Key</label>
+                        <Input
+                          id="hp-api-key"
+                          type="password"
+                          placeholder="Enter your API Key"
+                          value={hpApiKey}
+                          onChange={(e) => { setHpApiKey(e.target.value); setHpTestStatus("idle") }}
+                        />
+                      </div>
+                      {hpTestStatus === "success" && (
+                        <div className="flex items-center gap-2 text-sm text-success">
+                          <Check className="w-4 h-4" />
+                          Connected successfully.
+                        </div>
+                      )}
+                      {hpTestStatus === "error" && (
+                        <div className="text-sm text-destructive">
+                          {hpTestError || "Could not verify credentials."}
+                        </div>
+                      )}
+                      <div className="flex justify-between items-center pt-2">
+                        <button
+                          type="button"
+                          onClick={() => setCallLogProvider(null)}
+                          className="text-sm text-muted-foreground hover:text-foreground underline-offset-4 hover:underline"
+                        >
+                          Change provider
+                        </button>
+                        <Button
+                          type="button"
+                          className="btn-gradient gap-2"
+                          onClick={testHotProspectorConnection}
+                          disabled={hpTestStatus === "testing" || !hpApiUid || !hpApiKey}
+                        >
+                          {hpTestStatus === "testing" ? (
+                            <>
+                              <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                              Testing...
+                            </>
+                          ) : (
+                            "Test Connection"
+                          )}
+                        </Button>
+                      </div>
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+                </div>
+              </div>
+
+              {/* ── Footer: Back / Next-or-Create ──────────────── */}
+              <div className="flex items-center justify-between">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={wizardStep === 1 || addingClientGroup}
+                  onClick={() => setWizardStep(Math.max(1, wizardStep - 1))}
+                  className="gap-2"
+                >
+                  <ArrowLeft className="w-4 h-4" /> Back
+                </Button>
+                <Button
+                  type="button"
+                  onClick={handleCreateClientGroup}
+                  disabled={
+                    addingClientGroup
+                    || (wizardStep === 1 && !clientGroupName)
+                    || (wizardStep === 4 && !callLogProvider)
+                    || (wizardStep === 4 && callLogProvider === "hotprospector" && hpTestStatus !== "success")
+                  }
+                  className="btn-gradient gap-2 h-10 px-4 rounded-md min-w-[160px] justify-center"
+                >
+                  {addingClientGroup ? (
+                    <>
+                      <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                      Creating...
+                    </>
+                  ) : wizardStep < 4 ? (
+                    <>Next <ArrowRight className="w-4 h-4" /></>
+                  ) : (
+                    <><Plus className="w-4 h-4" /> Create Client Group</>
+                  )}
+                </Button>
+              </div>
             </div>
           </div>
         </DialogContent>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,6 +51,8 @@
     --primary: hsl(260 70% 55%);
     /* #7C4DFF — Birdy purple (kept) */
     --primary-foreground: hsl(0 0% 100%);
+    --primary-glow: hsl(280 80% 65%);
+    /* lighter companion for gradient washes (btn-gradient, headings) */
 
     --secondary: hsl(0 0% 96%);
     --secondary-foreground: hsl(0 0% 12%);
@@ -63,6 +65,9 @@
 
     --destructive: hsl(0 84% 60%);
     --destructive-foreground: hsl(0 0% 100%);
+
+    --success: hsl(142 70% 42%);
+    --success-foreground: hsl(0 0% 100%);
 
     --border: hsl(0 0% 90%);
     --input: hsl(0 0% 90%);
@@ -121,8 +126,11 @@
   --color-popover-foreground: var(--popover-foreground);
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
+  --color-primary-glow: var(--primary-glow);
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
@@ -166,6 +174,7 @@
   --animate-pulse-gentle: pulse-gentle 2s infinite;
   --animate-fade-in: fadeIn 0.5s ease-out;
   --animate-fade-out: fadeOut 0.3s ease-out;
+  --animate-slide-in: slide-in 0.35s ease-out;
 
   @keyframes accordion-down {
     from {
@@ -220,6 +229,18 @@
     to {
       opacity: 0;
       transform: translateY(10px);
+    }
+  }
+
+  @keyframes slide-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0);
     }
   }
 }
@@ -356,4 +377,61 @@
 
 @media (prefers-reduced-motion: reduce) {
   .birdy-flap:hover { animation: none; }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   Linking Wizard — stepper, card, gradient button
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Stepper node states — applied to a w-10 h-10 rounded-full container */
+.stepper-pending {
+  background-color: var(--muted);
+  color: var(--muted-foreground);
+  border: 2px solid var(--border);
+}
+
+.stepper-completed {
+  background-color: var(--success);
+  color: var(--success-foreground);
+  border: 2px solid var(--success);
+}
+
+.stepper-active {
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+  border: 2px solid var(--primary);
+  box-shadow: 0 0 0 4px hsl(260 70% 55% / 0.18);
+}
+
+/* Card panel housing the active step body */
+.card-gradient {
+  background-image: linear-gradient(135deg, var(--card) 0%, hsl(0 0% 98%) 100%);
+}
+
+.shadow-card {
+  box-shadow:
+    0 1px 3px 0 hsl(0 0% 0% / 0.06),
+    0 8px 24px -6px hsl(0 0% 0% / 0.10);
+}
+
+/* Gradient primary button — used for Test Connection, Next, Create */
+.btn-gradient {
+  background-image: linear-gradient(135deg, var(--primary) 0%, var(--primary-glow) 100%);
+  border: none;
+  color: var(--primary-foreground);
+  transition: filter 0.2s ease, box-shadow 0.2s ease, transform 0.1s ease;
+}
+
+.btn-gradient:hover:not(:disabled) {
+  filter: brightness(1.05);
+  box-shadow: 0 6px 18px -6px hsl(260 70% 55% / 0.45);
+}
+
+.btn-gradient:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.btn-gradient:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }

--- a/src/app/login/LoginForm.jsx
+++ b/src/app/login/LoginForm.jsx
@@ -17,7 +17,6 @@ export default function LoginForm() {
   const [formData, setFormData] = useState({
     email: "",
     password: "",
-    rememberMe: false,
   })
   const [error, setError] = useState("")
   const [showPassword, setShowPassword] = useState(false)
@@ -53,10 +52,12 @@ export default function LoginForm() {
       }
 
       // ── 2. Persist session ───────────────────────────────────────────────
+      // Client-side auth flag matches the backend JWT_EXPIRY_MINUTES (30 days).
+      // We used to give un-remembered logins a 1-hour TTL here, but that flag
+      // is what ProtectedLayout reads to gate the app — so users were getting
+      // bounced to /login every hour even though their cookie was still valid.
       const now = new Date()
-      const expiresAt = formData.rememberMe
-        ? new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000) // 30 days
-        : new Date(now.getTime() + 60 * 60 * 1000)            // 1 hour
+      const expiresAt = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000) // 30 days
 
       localStorage.setItem("user", JSON.stringify(data.user))
       localStorage.setItem(


### PR DESCRIPTION
## Summary

- Revamps the client onboarding wizard with a stepper-based dialog and a new **step 4** that picks the call log provider (GoHighLevel | Hot Prospector) per client.
- Rewires **Sales-Hub** to fetch data per-client based on `call_log_provider`: GHL reads from the new `/api/call_logs` endpoint (populated by the GHL workflow webhook); Hot Prospector shows a "coming soon" placeholder.
- Fixes the **hourly-logout bug**: the client-side `user_authenticated` flag was being stamped with a 1-hour TTL when the (invisible) "Remember Me" checkbox was unchecked. Both paths now use 30 days, matching backend `JWT_EXPIRY_MINUTES`. Vestigial `rememberMe` state removed.

## Test plan

- [ ] Open the wizard, walk through Name → GHL → Meta → Provider; verify the stepper updates and the dialog is responsive at narrow viewports.
- [ ] Pick GoHighLevel → Create; confirm `call_log_provider: "ghl"` lands on the new `client_groups` row.
- [ ] Pick Hot Prospector → enter test credentials → Test Connection → Create; confirm `call_log_provider: "hotprospector"` lands.
- [ ] In Sales-Hub, switch client selector between a GHL-provider client and an HP-provider one. GHL client shows `/api/call_logs` data; HP client shows the coming-soon panel.
- [ ] Log out, log in without ticking any "Remember Me" (there is none anymore), wait > 1 hour, refresh — should stay logged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sales Hub now allows selecting specific client groups with provider-aware call-log display (Hot Prospector shows "Coming Soon" placeholder)
  * New configuration step added for choosing call-log providers, including Hot Prospector with API credential entry and connection testing
  * Login sessions now use a consistent 30-day duration (removed "Remember Me" option for uniform session length)
  * Updated UI layouts with improved multi-step wizard and styling enhancements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nova-sudo/birdy-beta/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->