### PR TITLE
Auto-save column order on drag-reorder

### DIFF
--- a/src/app/clients/page.jsx
+++ b/src/app/clients/page.jsx
@@ -144,7 +144,7 @@ export default function ClientsPage() {
     try { return localStorage.getItem(STORAGE_KEY) ?? null; } catch { return null; }
   });
   const [currencyLoading, setCurrencyLoading] = useState(true);
-  const { savedColumns, saveView: saveToDB, viewsLoaded } = useColumnViews("clients")
+  const { savedColumns, saveView: saveToDB, saveViewDebounced, viewsLoaded } = useColumnViews("clients")
 
   // ── Filter groups by status ───────────────────────────────────────────────
   const filteredByStatus = useMemo(() => {
@@ -1283,7 +1283,13 @@ export default function ClientsPage() {
           isLoading={loading}
           isRowLoading={(row) => row._isPending || row._isCreating}
           initialColumnOrder={columnOrder}
-          onColumnOrderChange={setColumnOrder}
+          onColumnOrderChange={(newOrder) => {
+            setColumnOrder(newOrder)
+            // Auto-persist column order so a drag-reorder survives a refresh
+            // without the user having to click "Save View". Debounced inside
+            // the hook so a flurry of drags collapses to a single API call.
+            saveViewDebounced(newOrder)
+          }}
           enableStatusToggle={true}
           onStatusToggle={handleStatusToggle}
           togglingRows={togglingRows}

--- a/src/components/campaigns/MarketingContent.jsx
+++ b/src/components/campaigns/MarketingContent.jsx
@@ -123,10 +123,19 @@ export function MarketingContent({
 
   // One stable hook instance per tab — page keys never change between renders,
   // so hook call order is always the same (Rules of Hooks satisfied).
-  const { savedColumns: savedCampaigns, saveView: saveCampaigns, viewsLoaded: loadedCampaigns } = useColumnViews("mktg_campaigns")
-  const { savedColumns: savedAdsets,    saveView: saveAdsets,    viewsLoaded: loadedAdsets    } = useColumnViews("mktg_adsets")
-  const { savedColumns: savedAds,       saveView: saveAds,       viewsLoaded: loadedAds       } = useColumnViews("mktg_ads")
-  const { savedColumns: savedLeads,     saveView: saveLeads,     viewsLoaded: loadedLeads     } = useColumnViews("mktg_leads")
+  const { savedColumns: savedCampaigns, saveView: saveCampaigns, saveViewDebounced: saveCampaignsDebounced, viewsLoaded: loadedCampaigns } = useColumnViews("mktg_campaigns")
+  const { savedColumns: savedAdsets,    saveView: saveAdsets,    saveViewDebounced: saveAdsetsDebounced,    viewsLoaded: loadedAdsets    } = useColumnViews("mktg_adsets")
+  const { savedColumns: savedAds,       saveView: saveAds,       saveViewDebounced: saveAdsDebounced,       viewsLoaded: loadedAds       } = useColumnViews("mktg_ads")
+  const { savedColumns: savedLeads,     saveView: saveLeads,     saveViewDebounced: saveLeadsDebounced,     viewsLoaded: loadedLeads     } = useColumnViews("mktg_leads")
+
+  // Per-tab debounced-save lookup, used by the table's onColumnOrderChange to
+  // auto-persist drag-reorder events without needing a manual "Save View".
+  const saveDebouncedByTab = {
+    campaigns: saveCampaignsDebounced,
+    adsets:    saveAdsetsDebounced,
+    ads:       saveAdsDebounced,
+    leads:     saveLeadsDebounced,
+  }
 
   const [visibleColumns, setVisibleColumns] = useState(DEFAULT_VISIBLE_COLUMNS)
 
@@ -1186,9 +1195,11 @@ export function MarketingContent({
                   // already an ordered array of visible IDs — feed it as the
                   // initial order, and any drag updates the same slot.
                 initialColumnOrder={visibleColumns[activeTab] || []}
-                onColumnOrderChange={(newOrder) =>
+                onColumnOrderChange={(newOrder) => {
                   setVisibleColumns(prev => ({ ...prev, [activeTab]: newOrder }))
-                }
+                  // Auto-persist the new order for the active tab (debounced).
+                  saveDebouncedByTab[activeTab]?.(newOrder)
+                }}
               />
             )}
           </TabsContent>

--- a/src/components/contacts/LeadsContent.jsx
+++ b/src/components/contacts/LeadsContent.jsx
@@ -79,7 +79,7 @@ export function LeadsContent({
   }, [])
 
   const [currentPage, setCurrentPage] = useState(1)
-  const { savedColumns, saveView: saveToDB, viewsLoaded } = useColumnViews("contacts")
+  const { savedColumns, saveView: saveToDB, saveViewDebounced, viewsLoaded } = useColumnViews("contacts")
 
   // Filter to GHL groups only
   const ghlClientGroups = useMemo(
@@ -610,6 +610,8 @@ export function LeadsContent({
           initialColumnOrder={visibleColumns}
           onColumnOrderChange={(newOrder) => {
             setVisibleColumns(newOrder)
+            // Auto-persist on drag-reorder (debounced inside the hook).
+            saveViewDebounced(newOrder)
           }}
         />
 

--- a/src/lib/useColumnViews.js
+++ b/src/lib/useColumnViews.js
@@ -2,7 +2,7 @@
 // Shared hook for loading & saving per-page column views from the backend.
 // Now with localStorage cache — if views were prefetched at login, this returns instantly.
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { toast } from "sonner"
 import { API_BASE_URL } from "@/lib/api"
 import { getCachedData, setCachedData, clearCache } from "@/lib/cache"
@@ -88,5 +88,31 @@ export function useColumnViews(page) {
     [page]
   )
 
-  return { savedColumns, saveView, viewsLoaded }
+  // ── Debounced auto-save ──────────────────────────────────────────────────
+  // Used by pages to persist column order changes (drag-reorder events) the
+  // moment they happen — no need for the user to click "Save View". Rapid
+  // consecutive reorders are collapsed into a single API call after `delay`
+  // ms of silence so the network doesn't get hammered.
+  const debounceTimerRef = useRef(null)
+
+  const saveViewDebounced = useCallback(
+    (columns, delay = 600) => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
+      debounceTimerRef.current = setTimeout(() => {
+        saveView(columns)
+        debounceTimerRef.current = null
+      }, delay)
+    },
+    [saveView]
+  )
+
+  // Clear any pending debounced save when the component unmounts so we don't
+  // fire a PATCH against a navigated-away page.
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
+    }
+  }, [])
+
+  return { savedColumns, saveView, saveViewDebounced, viewsLoaded }
 }


### PR DESCRIPTION
## Summary

- New `saveViewDebounced(columns, delay=600)` in `useColumnViews` — debounced wrapper around `saveView` with unmount cleanup.
- Clients, Contacts, and Marketing Hub now call it from each table's `onColumnOrderChange`, so dragging a column to a new position persists ~600ms later automatically (no need to click Save View).
- Rapid consecutive drags collapse to a single `PATCH /api/user/views`.
- Marketing Hub uses a per-tab lookup so each of its four tabs manages its own debounce timer.
- Manual Save View still works the same; visibility toggles remain a manual-save action (out of scope).

## Test plan

- [ ] Clients page: drag a column → ~600ms later, "View saved!" toast → refresh → new order persists.
- [ ] Contacts page: same.
- [ ] Marketing Hub: same on every tab (campaigns / adsets / ads / leads).
- [ ] Rapid 3-drag sequence on the same tab → only one toast/save fires after the last drop.
- [ ] Navigate away mid-drag (within the 600ms window) → no orphaned PATCH (check Network).
- [ ] Manual "Save View" button still works for visibility-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)