### PR TITLE
Lead/contact count cards on Leads page

### DIFF
--- a/src/components/contacts/ContactStats.jsx
+++ b/src/components/contacts/ContactStats.jsx
@@ -1,25 +1,82 @@
-import { Target, TrendingUp } from "lucide-react"
+import { Target, TrendingUp, UserPlus, Users } from "lucide-react"
 import { StatsCard } from "@/components/StatsCard"
 
+/**
+ * Stats cards for the Leads page.
+ *
+ * Two rows:
+ *   1. Lead vs Contact counts (top). A contact is a "Lead" iff its first-
+ *      touch attribution is Facebook paid social — see
+ *      services/contact_classifier.py on the backend.
+ *   2. Opportunity stats (bottom), now scoped to lead-classified contacts
+ *      only. Same numbers and labels as before, but the underlying query
+ *      drops opportunities whose parent contact is a plain "contact".
+ */
 export function ContactStats({ metaStats, loading }) {
+  const leadCount = metaStats?.lead_count || 0
+  const contactCount = metaStats?.contact_count || 0
+
   const totalOpportunities = metaStats?.total_opportunities || 0
-  const wonCount = metaStats?.won || 0
   const lostCount = metaStats?.lost || 0
   const openCount = metaStats?.open || 0
   const conversionRate = metaStats?.conversion_rate || 0
 
-  const stats = [
-    { title: "Total Leads", value: totalOpportunities, icon: Target, subtitle: "Across all Leads" },
-    { title: "Lost Leads", value: lostCount, icon: Target, subtitle: "Across all Leads" },
-    { title: "Open Leads", value: openCount, icon: Target, subtitle: "Across all Leads" },
-    { title: "Conversion Rate", value: `${conversionRate}%`, icon: TrendingUp, subtitle: "Across all Leads" },
+  // ── Row 1 — contact classification counts ────────────────────────────────
+  const countStats = [
+    {
+      title: "Total Leads",
+      value: leadCount,
+      icon: UserPlus,
+      subtitle: "From Facebook paid social",
+    },
+    {
+      title: "Total Contacts",
+      value: contactCount,
+      icon: Users,
+      subtitle: "All other sources",
+    },
+  ]
+
+  // ── Row 2 — opportunity stats (lead-classified contacts only) ────────────
+  const opportunityStats = [
+    {
+      title: "Total Opportunities",
+      value: totalOpportunities,
+      icon: Target,
+      subtitle: "Across lead-classified contacts",
+    },
+    {
+      title: "Lost Leads",
+      value: lostCount,
+      icon: Target,
+      subtitle: "Across lead-classified contacts",
+    },
+    {
+      title: "Open Leads",
+      value: openCount,
+      icon: Target,
+      subtitle: "Across lead-classified contacts",
+    },
+    {
+      title: "Conversion Rate",
+      value: `${conversionRate}%`,
+      icon: TrendingUp,
+      subtitle: "Across lead-classified contacts",
+    },
   ]
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-      {stats.map((stat, index) => (
-        <StatsCard key={index} {...stat} loading={loading} />
-      ))}
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {countStats.map((stat, index) => (
+          <StatsCard key={`count-${index}`} {...stat} loading={loading} />
+        ))}
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {opportunityStats.map((stat, index) => (
+          <StatsCard key={`opp-${index}`} {...stat} loading={loading} />
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Adds a top row of cards to the Leads page showing **Total Leads** and **Total Contacts**, sourced from the new `lead_count` / `contact_count` fields on `/api/leads/unified`. The existing opportunity row stays where it is, but its subtitle now reads "Across lead-classified contacts" because the backend recomputes those stats from contacts where `lead_type == "lead"`.

Pairs with the backend change `feat(leads): classify lead vs contact by Facebook paid-social attribution` (already on `main`).

## Deployment order

1. Backend deployed (already on main, commit `e256930`).
2. **Run the one-time backfill** so existing contacts pick up `lead_type`:
   ```bash
   python -m scripts.backfill_lead_type
   ```
3. Merge this PR to deploy the frontend cards.

Without the backfill, the new top-row cards report `0` for every client and the opportunity cards also read `0/0/0/0` (because the filtered aggregation requires `lead_type` to be stamped on docs).

## Test plan

- [ ] After backfill, open the Leads page → see two new cards on top (Total Leads + Total Contacts) and four opportunity cards below.
- [ ] Filter by a single client group → counts update.
- [ ] Lead count + Contact count == total contacts displayed in the table for that filter.
- [ ] A contact with `attributionSource.utmSource == "facebook"` AND `attributionSource.sessionSource == "Paid Social"` shows `type: "lead"` in the table.
- [ ] All other contacts show `type: "contact"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured contact statistics layout from a single grid view into a two-row format for better organization. The first row now displays total leads and contact counts; the second row shows opportunity metrics including total opportunities, open deals, closed losses, and conversion rates specific to lead-classified contacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->