### PR TITLE
fix(marketing): show Flask icon for custom metrics regardless of dash…

### DIFF
--- a/src/components/campaigns/MarketingContent.jsx
+++ b/src/components/campaigns/MarketingContent.jsx
@@ -20,7 +20,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Label } from "@/components/ui/label"
 import { metaIcon as metaa, flaskIcon as Flask, ghlIcon as ghlIco } from "@/lib/icons"
-import { getMetricDisplayName } from "@/lib/metrics"
+import { getMetricDisplayName, getCustomMetricById } from "@/lib/metrics"
 import StyledTable from "@/components/ui/table-container"
 import ColumnVisibilityDropdown from "@/components/ui/Columns-filter"
 import getSymbolFromCurrency from "currency-symbol-map"
@@ -816,10 +816,12 @@ export function MarketingContent({
       const customMatch = customMetrics.find(m => m.id === col)
       const displayName = customMatch ? customMatch.name : getMetricDisplayName(col)
       // Determine source icon for table header
+      // Use global cache so metrics filtered from local state (different dashboard) still get Flask icon
+      const isCustomMetric = customMatch || !!getCustomMetricById(col)
       let colIcon = metaa
       if (col === "clientGroup" || col === "name" || col === "full_name") colIcon = null
       else if (col.startsWith("ghl_") || col.startsWith("tag_")) colIcon = ghlIco
-      else if (customMatch) colIcon = Flask
+      else if (isCustomMetric) colIcon = Flask
 
       return {
         id: col, key: col,


### PR DESCRIPTION
…board assignment

Custom metrics filtered from local state (due to dashboard mismatch) were falling through to the default Meta icon. Now checks the global cache as fallback so all custom metric columns render the correct Flask icon.
<img width="1917" height="920" alt="image" src="https://github.com/user-attachments/assets/7cef1c5c-06bb-4d4f-91d0-7cbebe81b212" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected custom metric indicators displayed in marketing table column headers to reflect metric status accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->