### PR TITLE
feat(sales-hub,clients): surface HotProspector talk time per client

### DIFF
--- a/src/app/Sales-Hub/page.jsx
+++ b/src/app/Sales-Hub/page.jsx
@@ -187,6 +187,7 @@ const OVERVIEW_COLUMNS = [
   { id: "inbound", label: "Inbound", sortable: true, icons: HP },
   { id: "outbound", label: "Outbound", sortable: true, icons: HP },
   { id: "transfers", label: "Transfers", sortable: true, icons: HP },
+  { id: "talk_time", label: "Talk Time (min)", sortable: true, icons: HP },
 ]
 
 const STATUS_CELL = (_v, row) => (
@@ -595,6 +596,7 @@ export default function CallCenterPage() {
           inbound: cs.inbound_count ?? 0,
           outbound: cs.outbound_count ?? 0,
           transfers: cs.transfers ?? 0,
+          talk_time: cs.total_talk_min ?? 0,
           original: g,
         }
       }),

--- a/src/app/clients/[id]/page.jsx
+++ b/src/app/clients/[id]/page.jsx
@@ -36,8 +36,8 @@ function ComingSoon({ title }) {
 // ── Stat Cards Skeleton ──────────────────────────────────────────────────────
 function StatCardsSkeleton() {
   return (
-    <div className="grid gap-4 md:grid-cols-4">
-      {Array.from({ length: 4 }).map((_, i) => (
+    <div className="grid gap-4 md:grid-cols-5">
+      {Array.from({ length: 5 }).map((_, i) => (
         <Card key={i} className="bg-white">
           <CardContent className="pt-0">
             <div className="flex justify-between items-start">
@@ -133,7 +133,8 @@ export default function ClientDetailsPage() {
     const totalClicks = campaigns.reduce((s, c) => s + (c.clicks || 0), 0)
     const totalImpressions = campaigns.reduce((s, c) => s + (c.impressions || 0), 0)
     const avgCtr = totalImpressions > 0 ? ((totalClicks / totalImpressions) * 100).toFixed(2) : "0"
-    return { totalSpend, totalClicks, totalImpressions, avgCtr }
+    const totalTalkMin = matchingGroup?.hotprospector?.call_stats?.total_talk_min ?? 0
+    return { totalSpend, totalClicks, totalImpressions, avgCtr, totalTalkMin }
   }, [matchingGroup])
 
   // ── Fetch client details (for notes) ───────────────────────────────────────
@@ -303,7 +304,7 @@ export default function ClientDetailsPage() {
           {groupsLoading ? (
             <StatCardsSkeleton />
           ) : (
-            <div className="grid gap-4 md:grid-cols-4">
+            <div className="grid gap-4 md:grid-cols-5">
               <Card className="bg-white border-purple-100">
                 <CardContent className="pt-0">
                   <div className="flex justify-between items-start">
@@ -362,6 +363,20 @@ export default function ClientDetailsPage() {
                       <svg className="h-4 w-4 text-orange-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
                       </svg>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card className="bg-white border-teal-100">
+                <CardContent className="pt-0">
+                  <div className="flex justify-between items-start">
+                    <div>
+                      <p className="text-muted-foreground text-sm text-[#71658B]">Talk Time (min)</p>
+                      <h3 className="text-2xl font-bold mt-1">{metrics.totalTalkMin.toLocaleString()}</h3>
+                    </div>
+                    <div className="h-7 w-7 bg-teal-100 rounded-md flex items-center justify-center">
+                      <Clock className="h-4 w-4 text-teal-600" />
                     </div>
                   </div>
                 </CardContent>

--- a/src/lib/enhanced-columns-config.js
+++ b/src/lib/enhanced-columns-config.js
@@ -50,7 +50,7 @@ export const BASE_CLIENT_COLUMNS = [
   { id: "hp_transfers", label: "Transfers", visible: false, sortable: true, icons: HP, category: 'hotprospector', type: 'data' },
   { id: "hp_leads_with_calls", label: "Leads Called", visible: true, sortable: true, icons: HP, category: 'hotprospector', type: 'data' },
   { id: "hp_answered_calls", label: "Answered Calls", visible: false, sortable: true, icons: HP, category: 'hotprospector', type: 'data' },
-  { id: "hp_talk_time", label: "Talk Time (min)", visible: false, sortable: true, icons: HP, category: 'hotprospector', type: 'data' },
+  { id: "hp_talk_time", label: "Talk Time (min)", visible: true, sortable: true, icons: HP, category: 'hotprospector', type: 'data' },
   { id: "hp_connect_rate", label: "Connect Rate", visible: false, sortable: true, icons: HP, category: 'hotprospector', type: 'data' },
   { id: "hp_answer_rate", label: "Answer Rate", visible: false, sortable: true, icons: HP, category: 'hotprospector', type: 'data' },
 


### PR DESCRIPTION
Talk time (total_talk_min) was already computed by the hp-tick cron and cached per client group, but nothing rendered it. Adds it as a Sales Hub column, a Clients page column (previously hidden by default), and a stat card on the client Overview tab.
<img width="1912" height="952" alt="image" src="https://github.com/user-attachments/assets/cd4d0aad-6f00-4af1-b597-6fddaf06ddc7" />
<img width="1917" height="961" alt="image" src="https://github.com/user-attachments/assets/7fec7f52-5a0a-4711-a72b-6ec194fdfe44" />
<img width="1117" height="256" alt="image" src="https://github.com/user-attachments/assets/eaee7880-6adc-4dde-937c-882ddb8e497a" />
