### PR TITLE
fix(client-picker): cap dropdown width across Sales Hub, Marketing, L…

### DIFF
--- a/src/app/Sales-Hub/page.jsx
+++ b/src/app/Sales-Hub/page.jsx
@@ -943,7 +943,7 @@ export default function CallCenterPage() {
                 <ChevronDown className={`w-4 h-4 shrink-0 text-gray-400 transition-transform ${gridOpen ? "rotate-180" : ""}`} />
               </button>
               {gridOpen && (
-                <div className="absolute z-50 mt-1 right-0 bg-white border border-gray-200 rounded-lg shadow-lg p-2 min-w-max">
+                <div className="absolute z-50 mt-1 right-0 w-[320px] max-w-[90vw] bg-white border border-gray-200 rounded-lg shadow-lg p-2">
                   <div className="mb-2">
                     <input
                       type="text"
@@ -954,7 +954,7 @@ export default function CallCenterPage() {
                     />
                   </div>
                   {filteredClientGrid.length > 0 ? (
-                    <div className="grid gap-1 max-h-72 overflow-y-auto" style={{ gridTemplateColumns: "repeat(5, minmax(100px, 1fr))" }}>
+                    <div className="grid gap-1 max-h-72 overflow-y-auto" style={{ gridTemplateColumns: "repeat(2, minmax(0, 1fr))" }}>
                       {filteredClientGrid.map((item) => {
                         const isSel = item.id === selectedClientGroup
                         return (
@@ -962,7 +962,7 @@ export default function CallCenterPage() {
                             key={item.id}
                             onClick={() => pickClient(item.id)}
                             title={item.name}
-                            className={`text-xs px-2.5 py-2 rounded-md border text-left truncate transition-colors whitespace-nowrap ${
+                            className={`text-xs px-2.5 py-2 rounded-md border text-left truncate transition-colors ${
                               isSel
                                 ? "bg-purple-600 text-white border-purple-600 font-semibold"
                                 : "bg-white text-gray-700 border-gray-200 hover:bg-gray-100 hover:border-gray-300"

--- a/src/components/campaigns/MarketingContent.jsx
+++ b/src/components/campaigns/MarketingContent.jsx
@@ -920,7 +920,7 @@ export function MarketingContent({
                   </button>
 
                   {gridOpen && (
-                    <div className="absolute z-50 mt-1 right-0 bg-white border border-gray-200 rounded-lg shadow-lg p-2 min-w-max">
+                    <div className="absolute z-50 mt-1 right-0 w-[320px] max-w-[90vw] bg-white border border-gray-200 rounded-lg shadow-lg p-2">
                       <div className="mb-2">
                         <input
                           type="text"
@@ -933,8 +933,8 @@ export function MarketingContent({
 
                       {filteredGridItems.length > 0 ? (
                         <div
-                          className="grid gap-1"
-                          style={{ gridTemplateColumns: "repeat(5, minmax(100px, 1fr))" }}
+                          className="grid gap-1 max-h-72 overflow-y-auto"
+                          style={{ gridTemplateColumns: "repeat(2, minmax(0, 1fr))" }}
                         >
                           {filteredGridItems.map(item => {
                             const isSelected =
@@ -951,7 +951,7 @@ export function MarketingContent({
                                   setGroupSearch("")
                                 }}
                                 title={item.name}
-                                className={`text-xs px-2.5 py-2 rounded-md border text-left truncate transition-colors whitespace-nowrap
+                                className={`text-xs px-2.5 py-2 rounded-md border text-left truncate transition-colors
                                   ${isSelected
                                     ? "bg-purple-600 text-white border-purple-600 font-semibold"
                                     : "bg-white text-gray-700 border-gray-200 hover:bg-gray-100 hover:border-gray-300"

--- a/src/components/contacts/LeadsContent.jsx
+++ b/src/components/contacts/LeadsContent.jsx
@@ -462,7 +462,7 @@ export function LeadsContent({
 
                       {/* Dropdown */}
                       {gridOpen && (
-                        <div className="absolute z-50 mt-1 right-0 bg-white border border-gray-200 rounded-lg shadow-lg p-2 min-w-max">
+                        <div className="absolute z-50 mt-1 right-0 w-[320px] max-w-[90vw] bg-white border border-gray-200 rounded-lg shadow-lg p-2">
 
                           {/* Search */}
                           <div className="mb-2 relative">
@@ -478,8 +478,8 @@ export function LeadsContent({
                           {/* Grid */}
                           {filteredGridItems.length > 0 ? (
                             <div
-                              className="grid gap-1"
-                              style={{ gridTemplateColumns: "repeat(5, minmax(100px, 1fr))" }}
+                              className="grid gap-1 max-h-72 overflow-y-auto"
+                              style={{ gridTemplateColumns: "repeat(2, minmax(0, 1fr))" }}
                             >
                               {filteredGridItems.map(item => {
                                 const isSelected =
@@ -496,7 +496,7 @@ export function LeadsContent({
                                       setGroupSearch("")
                                     }}
                                     title={item.name}
-                                    className={`text-xs px-2.5 py-2 rounded-md border text-left truncate transition-colors whitespace-nowrap
+                                    className={`text-xs px-2.5 py-2 rounded-md border text-left truncate transition-colors
                                       ${isSelected
                                         ? "bg-purple-600 text-white border-purple-600 font-semibold"
                                         : "bg-white text-gray-700 border-gray-200 hover:bg-gray-100 hover:border-gray-300"


### PR DESCRIPTION
…eads

The client/group picker dropdown used min-w-max with a 5-column grid of minmax(100px, 1fr) cells and whitespace-nowrap labels, which forced the browser to size the panel to fit every client name at full un-truncated width — blowing it out across most of the screen. Caps the panel to 320px (90vw max) and drops to a 2-column minmax(0, 1fr) grid so truncate actually takes effect; full names still show via the title tooltip.
<img width="566" height="596" alt="image" src="https://github.com/user-attachments/assets/a6df5c9f-370a-45ff-85c4-a4cfc658d29a" />
