### PR TITLE
feat(dashboard): undo an applied suggestion

### DIFF
--- a/src/app/dashboard/page.jsx
+++ b/src/app/dashboard/page.jsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import {
   useDashboardData,
   applySuggestion,
+  undoSuggestion,
   dismissSuggestion,
   runAlertAction,
   completeWin,
@@ -328,10 +329,32 @@ export default function DashboardPage() {
     }, 300);
   };
 
+  const restoreSuggestion = (item) =>
+    setSuggestions((prev) => (prev.some((s) => s.id === item.id) ? prev : [item, ...prev]));
+
   const handleApply = async (item) => {
-    toast.success("Birdy is on it", { description: item.title });
     removeItem("suggestions", item.id);
-    await applySuggestion(item.id);
+    const ok = await applySuggestion(item.id);
+    if (!ok) {
+      restoreSuggestion(item);
+      toast.error("Couldn't apply that", { description: item.title });
+      return;
+    }
+    toast.success("Done — ads paused", {
+      description: item.title,
+      duration: 10000,
+      action: {
+        label: "Undo",
+        onClick: async () => {
+          if (await undoSuggestion(item.id)) {
+            restoreSuggestion(item);
+            toast.success("Undone — ads re-enabled", { description: item.title });
+          } else {
+            toast.error("Couldn't undo", { description: item.title });
+          }
+        },
+      },
+    });
   };
 
   const handleDismiss = async (item) => {

--- a/src/app/dashboard/useDashboardData.js
+++ b/src/app/dashboard/useDashboardData.js
@@ -19,6 +19,7 @@ import {
 //     → { suggestions: [...], alerts: [...], wins: [...], activity: [...],
 //         counts: { suggestions, alerts, wins } }
 //   POST   /api/dashboard/suggestions/:id/apply
+//   POST   /api/dashboard/suggestions/:id/undo
 //   DELETE /api/dashboard/suggestions/:id
 //   POST   /api/dashboard/alerts/:id/action   body: { action: "open_client" | "view_all" }
 //   POST   /api/dashboard/wins/:id/complete
@@ -77,6 +78,16 @@ export function useDashboardData() {
 export async function applySuggestion(id) {
   try {
     const res = await apiRequest(`/api/dashboard/suggestions/${id}/apply`, { method: "POST" });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Reverse an applied suggestion — re-enables exactly the ads it paused. */
+export async function undoSuggestion(id) {
+  try {
+    const res = await apiRequest(`/api/dashboard/suggestions/${id}/undo`, { method: "POST" });
     return res.ok;
   } catch {
     return false;


### PR DESCRIPTION
"Do it for me" now shows an **Undo** action in the toast (10s) that re-enables the paused ads and restores the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)