### PR TITLE
Hide suggestion_created entries from dashboard activity feed

### DIFF
--- a/src/app/dashboard/page.jsx
+++ b/src/app/dashboard/page.jsx
@@ -478,9 +478,12 @@ export default function DashboardPage() {
                     </div>
                   </div>
                 ))
-              : activity.slice(0, 10).map((a) => (
-                  <ActivityItem key={a.id} {...a} onUndo={() => handleUndo(a)} />
-                ))}
+              : activity
+                  .filter((a) => a.kind !== "suggestion_created")
+                  .slice(0, 10)
+                  .map((a) => (
+                    <ActivityItem key={a.id} {...a} onUndo={() => handleUndo(a)} />
+                  ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Keep the icon/tone mapping in ActivityItem.jsx untouched (still used elsewhere) but filter these entries out before rendering on the dashboard.