### PR TITLE
Clients: default the status filter to Active

### DIFF
--- a/src/app/clients/page.jsx
+++ b/src/app/clients/page.jsx
@@ -106,7 +106,9 @@ export default function ClientsPage() {
   const [togglingRows, setTogglingRows] = useState(new Set())
 
   // ── Status filter ─────────────────────────────────────────────────────────
-  const [statusFilter, setStatusFilter] = useState("all")
+  // Defaults to "Active" — the hub opens on the clients being worked on, and
+  // inactive/all stay one click away.
+  const [statusFilter, setStatusFilter] = useState("Active")
 
   // Sync hook data → local state (local state allows optimistic updates)
   useEffect(() => {


### PR DESCRIPTION
The Client Hub opened on "All Clients", so inactive clients padded the list every visit. Start on Active instead — Inactive and All are still one click away in the filter bar.