### PR TITLE
Activity feeds: show applied actions and dismissals only

### DIFF
--- a/src/app/clients/[id]/page.jsx
+++ b/src/app/clients/[id]/page.jsx
@@ -9,7 +9,7 @@ import { ArrowLeft, DollarSign, Clock, Trash2, AlertTriangle, Loader2, Settings 
 import { toast } from "sonner"
 import { apiRequest } from "@/lib/api"
 import { useDashboardData } from "@/app/dashboard/useDashboardData"
-import { ActivityItem } from "@/components/activity/ActivityItem"
+import { ActivityItem, isFeedActivity } from "@/components/activity/ActivityItem"
 import { useClientGroups } from "@/lib/useClientGroups"
 import { DEFAULT_DATE_PRESET } from "@/lib/constants"
 import { DateRangeSelect } from "@/components/DateRangeSelect"
@@ -120,7 +120,7 @@ export default function ClientDetailsPage() {
   const { activity, loading: activityLoading } = useDashboardData()
   const groupNameForActivity = clientData?.group_info?.name
   const clientActivity = useMemo(
-    () => activity.filter((a) => a.client === groupNameForActivity),
+    () => activity.filter((a) => a.client === groupNameForActivity && isFeedActivity(a)),
     [activity, groupNameForActivity]
   )
 

--- a/src/app/dashboard/page.jsx
+++ b/src/app/dashboard/page.jsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { toast } from "sonner";
-import { ActivityItem } from "@/components/activity/ActivityItem";
+import { ActivityItem, isFeedActivity } from "@/components/activity/ActivityItem";
 import {
   useDashboardData,
   applySuggestion,
@@ -325,10 +325,10 @@ export default function DashboardPage() {
     return "Good evening";
   }, []);
 
-  // Everything the feed is willing to show — suggestion_created entries are
-  // noise here, so they count for nothing either.
+  // Everything the feed is willing to show — applied actions and dismissals
+  // only. Everything else is noise here, so it counts for nothing either.
   const visibleActivity = useMemo(
-    () => activity.filter((a) => a.kind !== "suggestion_created"),
+    () => activity.filter(isFeedActivity),
     [activity]
   );
 

--- a/src/components/activity/ActivityItem.jsx
+++ b/src/components/activity/ActivityItem.jsx
@@ -1,5 +1,12 @@
 import { Zap, Check, Trash2, Clock, RotateCcw } from "lucide-react";
 
+// The only kinds any feed surfaces: things that actually changed something.
+// Analysis passes, freshly-created suggestions and untyped legacy rows are
+// process noise and stay hidden everywhere.
+export const FEED_KINDS = ["action_applied", "suggestion_dismissed"];
+
+export const isFeedActivity = (a) => FEED_KINDS.includes(a?.kind);
+
 // Icon + tone per activity kind, falling back to the actor when kind is absent.
 function activityVisual(kind, isBirdy) {
   switch (kind) {


### PR DESCRIPTION
Both feeds mixed real changes with process noise. Whitelist the two kinds that represent something actually happening — action_applied and suggestion_dismissed — in one shared place, and filter both surfaces through it: the dashboard Activity feed (which previously only excluded suggestion_created) and the client History Book (previously unfiltered).

The dashboard's "Changes today" counter reads from the same filtered list, so it now counts the same rows the feed shows.
<img width="1917" height="971" alt="image" src="https://github.com/user-attachments/assets/4727cb4d-b4b6-4ef2-9f29-8d5e4b8dc618" />
